### PR TITLE
Ignore VersionControlSettings.asset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,5 @@ Thumbs.db
 *NonOpenSource.meta
 
 UserSettings/Layouts/default-2021.dwlt
+
+VersionControlSettings.asset

--- a/ProjectSettings/VersionControlSettings.asset
+++ b/ProjectSettings/VersionControlSettings.asset
@@ -1,8 +1,0 @@
-%YAML 1.1
-%TAG !u! tag:unity3d.com,2011:
---- !u!890905787 &1
-VersionControlSettings:
-  m_ObjectHideFlags: 0
-  m_Mode: Perforce
-  m_CollabEditorSettings:
-    inProgressEnabled: 1


### PR DESCRIPTION
It contains local dev environment like connecting to a perforce server
or use meta files for versioning. File can't be edited if connecting
to an invalid perforce server.

