### PR TITLE
Improve FPS counter.

### DIFF
--- a/Assets/Src/Scripts/SeedAvatar/UI/FpsViewport.cs
+++ b/Assets/Src/Scripts/SeedAvatar/UI/FpsViewport.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 

--- a/Assets/Src/Scripts/SeedAvatar/UI/FpsViewport.cs
+++ b/Assets/Src/Scripts/SeedAvatar/UI/FpsViewport.cs
@@ -24,25 +24,25 @@ namespace SeedAvatar {
     public Color HighColor = Color.green;
     public Color MiddleColor = Color.yellow;
     public Color LowColor = Color.red;
-    public float UpdateInterval = 0.5F;
-    private float _lastInterval;
-    private int _frameCount;
+    private int _frameCount = 0;
     private Text _fpsLabel;
 
     void Start() {
-      _lastInterval = Time.realtimeSinceStartup;
-      _frameCount = 0;
       _fpsLabel = GetComponent<Text>();
+      StartCoroutine(Loop());
     }
 
     void Update() {
       ++_frameCount;
-      if (Time.realtimeSinceStartup > _lastInterval + UpdateInterval) {
-        float fps = _frameCount / (Time.realtimeSinceStartup - _lastInterval);
-        _frameCount = 0;
-        _lastInterval = Time.realtimeSinceStartup;
-        _fpsLabel.text = string.Format("fps: {0:0.##}", fps);//#0.00
+    }
+
+    private IEnumerator Loop() {
+      while (true) {
+        yield return new WaitForSeconds(1);
+        int fps = _frameCount;
+        _fpsLabel.text = $"fps: {fps}";
         _fpsLabel.color = fps >= HighLevel ? HighColor : (fps > LowLevel ? MiddleColor : LowColor);
+        _frameCount = 0;
       }
     }
   }


### PR DESCRIPTION
This fix moves most computation off the UI thread, and the new implementation is also faster than the original implementation because it removes float points division, and calls to realtimeSinceStartup. (Measured only ~1 fps on M1 Air, but I think it would be more significant on slower hardware)

PS: Also get rid of the UpdateInterval config since I don't think it makes a huge difference to use other settings than a default 1 second refresh interval.